### PR TITLE
Add multilingual translations for hourly usage labels

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -26,6 +26,7 @@ export interface Translations {
     modelBreakdown: string;
     dailyBreakdown: string;
     monthlyBreakdown: string;
+    hourlyBreakdown: string;
     date: string;
     yesterday: string;
     dataDirectory: string;
@@ -68,6 +69,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       modelBreakdown: 'Model Usage',
       dailyBreakdown: 'Daily Usage',
       monthlyBreakdown: 'Monthly Usage',
+      hourlyBreakdown: 'Hourly Usage',
       date: 'Date',
       yesterday: 'Yesterday',
       dataDirectory: 'Data Directory',
@@ -108,6 +110,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       modelBreakdown: '模型使用量',
       dailyBreakdown: '每日使用量',
       monthlyBreakdown: '每月使用量',
+      hourlyBreakdown: '每小時使用量',
       date: '日期',
       yesterday: '昨日',
       dataDirectory: '資料目錄',
@@ -148,6 +151,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       modelBreakdown: '模型使用量',
       dailyBreakdown: '每日使用量',
       monthlyBreakdown: '每月使用量',
+      hourlyBreakdown: '每小时使用量',
       date: '日期',
       yesterday: '昨日',
       dataDirectory: '数据目录',
@@ -188,6 +192,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       modelBreakdown: 'モデル別使用量',
       dailyBreakdown: '日別使用量',
       monthlyBreakdown: '月別使用量',
+      hourlyBreakdown: '時間別使用量',
       date: '日付',
       yesterday: '昨日',
       dataDirectory: 'データディレクトリ',
@@ -228,6 +233,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       modelBreakdown: '모델별 사용량',
       dailyBreakdown: '일별 사용량',
       monthlyBreakdown: '월별 사용량',
+      hourlyBreakdown: '시간별 사용량',
       date: '날짜',
       yesterday: '어제',
       dataDirectory: '데이터 디렉토리',

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -315,7 +315,7 @@ export class UsageWebviewProvider {
       });
       
       hourlyBreakdown = '<div class="daily-breakdown">' +
-        '<h3>每小時使用量</h3>' +
+        '<h3>' + I18n.t.popup.hourlyBreakdown + '</h3>' +
         '<div class="chart-tabs">' +
           '<button class="chart-tab active" data-metric="cost">' + cost + '</button>' +
           '<button class="chart-tab" data-metric="inputTokens">' + inputTokens + '</button>' +
@@ -1648,7 +1648,7 @@ function renderHourlyData(hourlyData, date) {
   }
   
   let html = '<div class="hourly-breakdown">';
-  html += '<h4>' + new Date(date).toLocaleDateString() + ' 每小時使用量</h4>';
+  html += '<h4>' + new Date(date).toLocaleDateString() + ' ' + I18n.t.popup.hourlyBreakdown + '</h4>';
   
   // Chart tabs
   html += '<div class="chart-tabs">';


### PR DESCRIPTION
Add complete internationalization support for hourly usage display labels, including English, Traditional Chinese, Simplified Chinese, Japanese, and Korean translations. Replace hardcoded Chinese text in code with i18n translation system to ensure multilingual consistency in the user interface.

新增多語言翻譯支援每小時使用量標籤

為每小時使用量顯示標籤新增完整的國際化支援，包含英文、繁體中文、简体中文、日文及韓文翻譯。移除程式碼中硬編碼的中文文字，改用 i18n 翻譯系統以確保使用者界面的多語言一致性。