### PR TITLE
Fix webview/status bar getting stuck on "Loading…"

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,10 @@ export class ClaudeCodeUsageExtension {
   private fileWatcher: fs.FSWatcher | undefined;
   private watchDebounceTimer: NodeJS.Timeout | undefined;
   private watchedDir: string | null = null;
+  // Guards against overlapping refreshes. The auto-refresh timer and the file
+  // watcher can both fire while a (slow) full reload is still running; without
+  // this, reloads pile up and keep re-asserting the "Loading…" spinner.
+  private isRefreshing: boolean = false;
   private cache: {
     records: any[];
     contentAnalysis: ContentAnalysis | null;
@@ -402,6 +406,12 @@ export class ClaudeCodeUsageExtension {
   }
 
   private async refreshData(): Promise<void> {
+    // Coalesce overlapping refreshes — a trigger that arrives mid-load is
+    // dropped rather than starting a second full reload on top of the first.
+    if (this.isRefreshing) {
+      return;
+    }
+    this.isRefreshing = true;
     try {
       const config = this.getConfiguration();
 
@@ -432,8 +442,14 @@ export class ClaudeCodeUsageExtension {
         return;
       }
 
-      this.statusBar.setLoading(true);
-      this.webviewProvider.setLoading(true);
+      // Only show the full-screen spinner on the very first load (nothing on
+      // screen yet). Background refreshes keep the existing dashboard/status
+      // bar visible and swap in fresh data when ready — otherwise the panel
+      // flickers to "Loading…" on every file-watch tick during active use.
+      if (this.cache.records.length === 0) {
+        this.statusBar.setLoading(true);
+        this.webviewProvider.setLoading(true);
+      }
 
       const loaded = await ClaudeDataLoader.loadUsageRecords(dataDirectory, {
         analyzeContent: config.enableContentAnalysis
@@ -474,6 +490,8 @@ export class ClaudeCodeUsageExtension {
 
       this.statusBar.updateUsageData(null, null, errorMessage);
       this.webviewProvider.updateData(null, null, null, null, [], [], [], errorMessage, null);
+    } finally {
+      this.isRefreshing = false;
     }
   }
 


### PR DESCRIPTION
## Problem

During active Claude Code use the usage panel (and the status bar) often gets stuck showing the **"Loading…"** spinner and never renders the dashboard.

## Root cause

`refreshData()` is triggered by both the auto-refresh timer (≥30s) and the file watcher (1.5s debounce, which fires repeatedly while Claude Code is writing logs). On every trigger:

- `setLoading(true)` **replaces the entire webview HTML with the spinner** and flips the status bar to `$(sync~spin) Loading…`.
- `refreshData()` then re-reads and re-parses **every** JSONL file from scratch — seconds on a large history.
- There is **no re-entrancy guard**, so overlapping reloads pile up and a fresh `setLoading(true)` keeps re-asserting the spinner around the time each slow load finishes → effectively perpetual "Loading…".

## Fix

Two small, data-behaviour-preserving changes in `src/extension.ts`:

1. **Re-entrancy guard** (`isRefreshing`): a trigger that arrives while a load is in flight is coalesced instead of starting a second full reload on top of the first.
2. **Spinner only on first load**: the full-screen "Loading…" state is shown only when there is no data yet (cold cache). Background refreshes keep the existing dashboard / status-bar value visible and swap in fresh data when ready, via the existing `updateData()` / `updateUsageData()` calls.

Error and no-data paths are unchanged and still surface their messages.

## Testing

- `npm run compile` is clean.
- Manually: open the panel and either repeatedly run `Claude Code Usage: Refresh Usage Data` or use Claude Code so logs keep changing. Before: panel flickers to / sticks on the spinner. After: the dashboard stays visible and updates in place; the spinner only appears on the very first open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)