### PR TITLE
fix: correct preLaunchTask reference in launch.json (F5 fails)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
       "outFiles": [
         "${workspaceFolder}/out/**/*.js"
       ],
-      "preLaunchTask": "${workspaceFolder}/npm: compile"
+      "preLaunchTask": "npm: compile"
     }
   ]
 }


### PR DESCRIPTION
## Problem

Pressing **F5** ("Run Extension") fails with:

> Could not find the task '/…/ClaudeCodeUsage/npm: compile'.

`.vscode/launch.json` sets:

```jsonc
"preLaunchTask": "${workspaceFolder}/npm: compile"
```

The `${workspaceFolder}/` prefix is the *folder-scoped* task identifier form used in **multi-root** workspaces. In a normal single-root checkout of this repo it doesn't resolve to the task, so the debug launch aborts before the extension host opens.

## Is this not a problem for other devs?

It should be — this is committed config, not anything local to my machine, so I'd expect **anyone** who clones the repo and presses F5 to hit the same error. The task itself is defined correctly in `.vscode/tasks.json` (`type: npm`, `script: compile`), so the only thing wrong is the label reference in `launch.json`. Flagging in case it's been masked by people running `npm run watch`/`compile` manually instead of relying on the prelaunch task.

## Fix

Use the plain task label, which matches what `tasks.json` registers:

```jsonc
"preLaunchTask": "npm: compile"
```

F5 then runs the compile task and launches the Extension Development Host as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)