### PR TITLE
Fix: quota indicator (5h/wk %) gets stuck showing a stale value

### DIFF
--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -81,8 +81,17 @@ export class StatusBarManager {
    * Public so it can be refreshed on its own while the rest of the UI is idle.
    */
   updateQuota(usageLimits: ClaudeApiUsageResponse | null): void {
-    const fiveHour = usageLimits?.five_hour;
-    const weekly = usageLimits?.seven_day;
+    // A window's utilization is a point-in-time snapshot that is only valid
+    // until its resets_at. When the OAuth fetch starts failing (expired creds,
+    // 401/403, offline, rate-limited), maybeFetchUsageLimits() keeps handing us
+    // the last successful response — so without this guard we would keep
+    // rendering a value long after its window rolled over (e.g. a stale
+    // "5h:100%" that lingers for hours, or even survives a plan upgrade). Drop
+    // any window whose reset time has passed; if nothing current remains, hide
+    // the indicator rather than assert a number we can no longer trust.
+    const live = this.liveWindows(usageLimits);
+    const fiveHour = live?.five_hour;
+    const weekly = live?.seven_day;
     if (!fiveHour && !weekly) {
       this.quotaItem.hide();
       return;
@@ -110,8 +119,39 @@ export class StatusBarManager {
       this.quotaItem.backgroundColor = undefined;
     }
 
-    this.quotaItem.tooltip = this.createQuotaTooltip(usageLimits as ClaudeApiUsageResponse);
+    this.quotaItem.tooltip = this.createQuotaTooltip(live as ClaudeApiUsageResponse);
     this.quotaItem.show();
+  }
+
+  /**
+   * Return a copy of the usage response containing only the windows still
+   * inside their current period. A window whose resets_at has already passed
+   * has rolled over, so its cached utilization is stale and must not be shown
+   * (see updateQuota). A window with an unparseable resets_at is kept — we
+   * don't hide data we can't reason about. Returns null when nothing current
+   * remains, which collapses the indicator instead of showing a wrong figure.
+   */
+  private liveWindows(usageLimits: ClaudeApiUsageResponse | null): ClaudeApiUsageResponse | null {
+    if (!usageLimits) {
+      return null;
+    }
+    const now = Date.now();
+    const current = (limit?: ClaudeUsageLimit): ClaudeUsageLimit | undefined => {
+      if (!limit) {
+        return undefined;
+      }
+      const t = Date.parse(limit.resets_at);
+      return isNaN(t) || t > now ? limit : undefined;
+    };
+    const out: ClaudeApiUsageResponse = {
+      five_hour: current(usageLimits.five_hour),
+      seven_day: current(usageLimits.seven_day),
+      seven_day_opus: current(usageLimits.seven_day_opus)
+    };
+    if (!out.five_hour && !out.seven_day && !out.seven_day_opus) {
+      return null;
+    }
+    return out;
   }
 
   private showNoData(): void {


### PR DESCRIPTION
## Problem

The right-hand status-bar quota indicator (`5h:… wk:…`) can get **stuck showing an old percentage indefinitely**. A user reported a `5h:100%` that was carried over from a session hours earlier and stayed at `100%` even after they upgraded their plan.

### Root cause

Two behaviors compound:

1. **Indefinite stale fallback** — when the OAuth usage fetch fails (expired/rotated credentials, `401`/`403`, `429` cooldown, or offline), `maybeFetchUsageLimits()` returns the last *successful* response with no upper bound on age.
2. **No reset awareness** — `updateQuota()` rendered `utilization` directly, ignoring each window's `resets_at`.

So once a fetch returned e.g. `5h:100%` and later fetches kept failing silently, the extension kept displaying `100%` long after that 5-hour window had rolled over.

## Fix

A window's `utilization` is a point-in-time snapshot only valid until its `resets_at`. This PR adds `liveWindows()` in `statusBar.ts`, which strips out any window whose reset time has already passed before display:

- A rolled-over window is no longer rendered with its stale percentage.
- If nothing current remains, the indicator hides rather than asserting a number we can no longer trust.
- Windows with an unparseable `resets_at` are kept (we don't hide data we can't reason about).
- Genuine real-time values (a real `5h:100%` with a future reset) are unaffected.

This bounds staleness to each window's reset period (≤5h for `5h`, ≤1 week for `wk`) instead of forever.

## Testing

- `npm run compile` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)