### PR TITLE
feat: showCost toggle + context-window fill indicator in the status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this fork compared to upstream
 [`jack21/ClaudeCodeUsage`](https://github.com/jack21/ClaudeCodeUsage) (last
 upstream release: 1.0.8). Format follows [Keep a Changelog](https://keepachangelog.com).
 
+## [Unreleased]
+
+### Added
+- **Context-window indicator** in the status bar — shows the current
+  session's context fill as a percentage (like `/context`), estimated from
+  the latest log record (`input + cache read + cache write` tokens vs the
+  model's window; `[1m]` long-context variants use 1M). Amber at 80%, red at
+  95%; hidden after 5 h of inactivity. Toggle with
+  `claudeCodeUsage.showContext`.
+- **`claudeCodeUsage.showCost` setting** — hide the status-bar cost item for
+  those who only want the quota / context indicators (the dashboard still
+  shows all cost figures).
+
 ## [2.0.2] — 2026-06-09
 
 ### Added

--- a/README-en.md
+++ b/README-en.md
@@ -54,6 +54,7 @@ Open Settings (`Ctrl+,`) and search for **`Claude Code Usage`**. All settings ar
 - `timezone` — IANA timezone for date display (e.g. `Asia/Hong_Kong`).
 - `usageLimitTracking` — show the real 5h / weekly quota indicator.
 - `showCost` / `showContext` — toggle the cost item and the context-window fill indicator (like `/context`) in the status bar.
+- Each of these status-bar items is opt-out — set `usageLimitTracking`, `showCost`, or `showContext` to `false` to hide just that one.
 - `advice.apiKey` — API key for the AI advice feature (OpenAI-compatible).
 - `pauseDashboardRefresh` — pause dashboard auto-refresh (also toggleable in the dashboard header).
 

--- a/README-en.md
+++ b/README-en.md
@@ -53,6 +53,7 @@ Open Settings (`Ctrl+,`) and search for **`Claude Code Usage`**. All settings ar
 - `language` — UI language (`auto` / `en` / `zh-TW` / `zh-CN` / `ja` / `ko`).
 - `timezone` — IANA timezone for date display (e.g. `Asia/Hong_Kong`).
 - `usageLimitTracking` — show the real 5h / weekly quota indicator.
+- `showCost` / `showContext` — toggle the cost item and the context-window fill indicator (like `/context`) in the status bar.
 - `advice.apiKey` — API key for the AI advice feature (OpenAI-compatible).
 - `pauseDashboardRefresh` — pause dashboard auto-refresh (also toggleable in the dashboard header).
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -53,6 +53,7 @@ Cursor / Windsurf 向けに [Open VSX Registry](https://open-vsx.org/extension/G
 - `language` — UI 言語（`auto` / `en` / `zh-TW` / `zh-CN` / `ja` / `ko`）。
 - `timezone` — 日付表示用の IANA タイムゾーン（例 `Asia/Tokyo`）。
 - `usageLimitTracking` — 実際の 5 時間 / 週間クォータ表示。
+- `showCost` / `showContext` — ステータスバーのコスト表示と、コンテキストウィンドウ使用率（`/context` 風）の切り替え。
 - `advice.apiKey` — AI アドバイス機能の API キー（OpenAI 互換）。
 - `pauseDashboardRefresh` — ダッシュボードの自動更新を一時停止（ダッシュボードのヘッダーでも切り替え可能）。
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -54,6 +54,7 @@ Cursor / Windsurf 向けに [Open VSX Registry](https://open-vsx.org/extension/G
 - `timezone` — 日付表示用の IANA タイムゾーン（例 `Asia/Tokyo`）。
 - `usageLimitTracking` — 実際の 5 時間 / 週間クォータ表示。
 - `showCost` / `showContext` — ステータスバーのコスト表示と、コンテキストウィンドウ使用率（`/context` 風）の切り替え。
+- これらのステータスバー項目は個別に非表示にできます。`usageLimitTracking` / `showCost` / `showContext` を `false` にすると、その項目だけ消えます。
 - `advice.apiKey` — AI アドバイス機能の API キー（OpenAI 互換）。
 - `pauseDashboardRefresh` — ダッシュボードの自動更新を一時停止（ダッシュボードのヘッダーでも切り替え可能）。
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -54,6 +54,7 @@ Cursor / Windsurf용으로 [Open VSX Registry](https://open-vsx.org/extension/Gr
 - `timezone` — 날짜 표시용 IANA 시간대(예: `Asia/Seoul`).
 - `usageLimitTracking` — 실제 5시간 / 주간 쿼터 표시.
 - `showCost` / `showContext` — 상태 표시줄의 비용 항목과 컨텍스트 윈도우 사용률(`/context` 유사) 표시 전환.
+- 위 상태 표시줄 항목들은 개별적으로 끌 수 있습니다. `usageLimitTracking` / `showCost` / `showContext` 를 `false`로 설정하면 해당 항목만 숨겨집니다.
 - `advice.apiKey` — AI 조언 기능용 API 키(OpenAI 호환).
 - `pauseDashboardRefresh` — 대시보드 자동 새로고침 일시정지(대시보드 헤더에서도 토글 가능).
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -53,6 +53,7 @@ Cursor / Windsurf용으로 [Open VSX Registry](https://open-vsx.org/extension/Gr
 - `language` — UI 언어(`auto` / `en` / `zh-TW` / `zh-CN` / `ja` / `ko`).
 - `timezone` — 날짜 표시용 IANA 시간대(예: `Asia/Seoul`).
 - `usageLimitTracking` — 실제 5시간 / 주간 쿼터 표시.
+- `showCost` / `showContext` — 상태 표시줄의 비용 항목과 컨텍스트 윈도우 사용률(`/context` 유사) 표시 전환.
 - `advice.apiKey` — AI 조언 기능용 API 키(OpenAI 호환).
 - `pauseDashboardRefresh` — 대시보드 자동 새로고침 일시정지(대시보드 헤더에서도 토글 가능).
 

--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -98,7 +98,7 @@ ext install GrowthJack.claude-code-usage
 | `timezone` | `""` | 日期显示用的 IANA 时区（如 `Asia/Hong_Kong`）。 |
 | `usageLimitTracking` | `true` | 在状态栏显示真实 5h / 每周配额。 |
 | `showCost` | `true` | 在状态栏显示今日成本。 |
-| `showContext` | `true` | 在状态栏显示当前会话的上下文窗口占用（类似 `/context`）。 |
+| `showContext` | `true` | 在状态栏显示当前会话的上下文窗口占用（类似 `/context`）。把它、`showCost` 或 `usageLimitTracking` 设为 `false` 即可隐藏对应的状态栏项。 |
 | `enableContentAnalysis` | `true` | 运行 Content 标签页的 token 分析。 |
 | `projectGroupingMode` | `"git"` | Projects 标签分组：`git` / `folder` / `flat`。 |
 | `pauseDashboardRefresh` | `false` | 暂停仪表板自动刷新（也可在仪表板标题栏切换）。 |

--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -97,6 +97,8 @@ ext install GrowthJack.claude-code-usage
 | `compactNumbers` | `false` | 用 `1.2M` / `345K` 代替完整数字。 |
 | `timezone` | `""` | 日期显示用的 IANA 时区（如 `Asia/Hong_Kong`）。 |
 | `usageLimitTracking` | `true` | 在状态栏显示真实 5h / 每周配额。 |
+| `showCost` | `true` | 在状态栏显示今日成本。 |
+| `showContext` | `true` | 在状态栏显示当前会话的上下文窗口占用（类似 `/context`）。 |
 | `enableContentAnalysis` | `true` | 运行 Content 标签页的 token 分析。 |
 | `projectGroupingMode` | `"git"` | Projects 标签分组：`git` / `folder` / `flat`。 |
 | `pauseDashboardRefresh` | `false` | 暂停仪表板自动刷新（也可在仪表板标题栏切换）。 |

--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -53,6 +53,7 @@ ext install GrowthJack.claude-code-usage
 - `language` — 介面語言（`auto` / `en` / `zh-TW` / `zh-CN` / `ja` / `ko`）。
 - `timezone` — 日期顯示用的 IANA 時區（如 `Asia/Hong_Kong`）。
 - `usageLimitTracking` — 顯示真實的 5 小時 / 每週配額指示器。
+- `showCost` / `showContext` — 切換狀態列的成本項目與上下文視窗佔用指示器（類似 `/context`）。
 - `advice.apiKey` — AI 建議功能的 API key（OpenAI 相容）。
 - `pauseDashboardRefresh` — 暫停儀表板自動刷新（也可在儀表板標題列切換）。
 

--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -54,6 +54,7 @@ ext install GrowthJack.claude-code-usage
 - `timezone` — 日期顯示用的 IANA 時區（如 `Asia/Hong_Kong`）。
 - `usageLimitTracking` — 顯示真實的 5 小時 / 每週配額指示器。
 - `showCost` / `showContext` — 切換狀態列的成本項目與上下文視窗佔用指示器（類似 `/context`）。
+- 上述狀態列項目皆可個別隱藏：將 `usageLimitTracking` / `showCost` / `showContext` 設為 `false` 即可只隱藏該項。
 - `advice.apiKey` — AI 建議功能的 API key（OpenAI 相容）。
 - `pauseDashboardRefresh` — 暫停儀表板自動刷新（也可在儀表板標題列切換）。
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ reasonable.
 | `compactNumbers` | `false` | Show `1.2M` / `345K` instead of full numbers. |
 | `timezone` | `""` | IANA timezone for date display (e.g. `Asia/Hong_Kong`). |
 | `usageLimitTracking` | `true` | Show real 5h / weekly quota in the status bar. |
+| `showCost` | `true` | Show today's cost item in the status bar. |
+| `showContext` | `true` | Show the current session's context-window fill (like `/context`). |
 | `enableContentAnalysis` | `true` | Run the Content tab token analysis. |
 | `projectGroupingMode` | `"git"` | Projects tab grouping: `git` / `folder` / `flat`. |
 | `advice.apiKey` | `""` | API key for the AI advice feature (OpenAI-compatible). |

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ reasonable.
 | `timezone` | `""` | IANA timezone for date display (e.g. `Asia/Hong_Kong`). |
 | `usageLimitTracking` | `true` | Show real 5h / weekly quota in the status bar. |
 | `showCost` | `true` | Show today's cost item in the status bar. |
-| `showContext` | `true` | Show the current session's context-window fill (like `/context`). |
+| `showContext` | `true` | Show the current session's context-window fill (like `/context`). Set this, `showCost`, or `usageLimitTracking` to `false` to hide that status-bar item. |
 | `enableContentAnalysis` | `true` | Run the Content tab token analysis. |
 | `projectGroupingMode` | `"git"` | Projects tab grouping: `git` / `folder` / `flat`. |
 | `advice.apiKey` | `""` | API key for the AI advice feature (OpenAI-compatible). |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-usage",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-usage",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/glob": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,16 @@
           "default": "",
           "description": "IANA timezone for date display (e.g. \"Asia/Hong_Kong\", \"UTC\"). Leave empty to use the system timezone. Useful inside sandboxes/devcontainers. Day-boundary calculations still follow the system timezone."
         },
+        "claudeCodeUsage.showCost": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show today's cost in the status bar. Disable to hide the cost item — the dashboard still shows all cost figures."
+        },
+        "claudeCodeUsage.showContext": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show the current session's context-window fill (like /context) in the status bar. Estimated from the latest log record, so it updates with each new message."
+        },
         "claudeCodeUsage.usageLimitTracking": {
           "type": "boolean",
           "default": true,

--- a/src/dataLoader.ts
+++ b/src/dataLoader.ts
@@ -9,6 +9,7 @@ import {
   BranchUsage,
   ClaudeUsageRecord,
   ContentAnalysis,
+  ContextWindowInfo,
   ContentSlice,
   ProjectGroup,
   ProjectUsage,
@@ -863,6 +864,53 @@ export class ClaudeDataLoader {
       sessionStart: new Date(Math.min(...times)),
       sessionEnd: new Date(Math.max(...times)),
     };
+  }
+
+  /**
+   * Context-window fill of the current conversation — the input-side token
+   * count of the session's most recent request vs the model's window size.
+   * Mirrors what Claude Code's /context shows, estimated from the logs: after
+   * /clear or a compaction the figure only corrects on the next message.
+   * Same workspace scoping and 5-hour recency rule as getCurrentSessionData.
+   */
+  static getCurrentContextInfo(records: ClaudeUsageRecord[], workspacePath?: string): ContextWindowInfo | null {
+    let pool = records;
+    if (workspacePath) {
+      const scoped = this.filterByWorkspace(records, workspacePath);
+      if (scoped.length > 0) {
+        pool = scoped;
+      }
+    }
+    // Only real assistant requests carry context information — synthetic
+    // user-prompt markers and API-error records have zero usage.
+    pool = pool.filter((r) => this.recordContextTokens(r) > 0);
+    if (pool.length === 0) {
+      return null;
+    }
+
+    let latest = pool[0];
+    for (const r of pool) {
+      if (new Date(r.timestamp).getTime() > new Date(latest.timestamp).getTime()) {
+        latest = r;
+      }
+    }
+    if (Date.now() - new Date(latest.timestamp).getTime() > 5 * 60 * 60 * 1000) {
+      return null;
+    }
+
+    const model = latest.message.model || '';
+    return {
+      contextTokens: this.recordContextTokens(latest),
+      windowTokens: this.contextWindowFor(model),
+      model,
+    };
+  }
+
+  /** Model context-window size in tokens. A "[1m]" suffix marks the
+   * long-context variant (same marker pricing.ts strips); everything else
+   * Claude Code runs today has a 200K window. */
+  private static contextWindowFor(model: string): number {
+    return /\[1m\]/i.test(model) ? 1000000 : 200000;
   }
 
   static getTodayData(records: ClaudeUsageRecord[]): UsageData {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -277,6 +277,7 @@ export class ClaudeCodeUsageExtension {
     I18n.setDecimalPlaces(config.decimalPlaces);
     I18n.setCompactNumbers(config.compactNumbers);
     I18n.setTimezone(config.timezone);
+    this.statusBar.setVisibility(config.showCost, config.showContext);
 
     // Listen for configuration changes
     vscode.workspace.onDidChangeConfiguration(e => {
@@ -295,6 +296,8 @@ export class ClaudeCodeUsageExtension {
       decimalPlaces: config.get('decimalPlaces', 2),
       compactNumbers: config.get('compactNumbers', false),
       timezone: config.get('timezone', ''),
+      showCost: config.get('showCost', true),
+      showContext: config.get('showContext', true),
       usageLimitTracking: config.get('usageLimitTracking', true),
       // apiKey is the gate for the advice feature: ONLY read the new dotted
       // key. We deliberately do NOT fall back to the pre-2.0 flat
@@ -323,6 +326,7 @@ export class ClaudeCodeUsageExtension {
     I18n.setDecimalPlaces(config.decimalPlaces);
     I18n.setCompactNumbers(config.compactNumbers);
     I18n.setTimezone(config.timezone);
+    this.statusBar.setVisibility(config.showCost, config.showContext);
 
     // Restart auto-refresh with new interval
     this.startAutoRefresh();
@@ -528,6 +532,7 @@ export class ClaudeCodeUsageExtension {
       if (!dataDirectory) {
         const error = 'Claude data directory not found. Please check your configuration.';
         this.statusBar.updateUsageData(null, null, error);
+        this.statusBar.updateContext(null);
         if (updateWebview) {
           this.webviewProvider.updateData(null, null, null, null, [], [], [], error, null);
         }
@@ -542,7 +547,15 @@ export class ClaudeCodeUsageExtension {
         dirChanged || this.cache.records.length === 0 || latestMtime > this.cache.lastUpdate.getTime();
 
       if (!needFullRefresh) {
-        // Idle: logs unchanged. Quota was already refreshed above.
+        // Idle: logs unchanged. Quota was already refreshed above. Still
+        // recompute the context indicator from cache so its 5-hour recency
+        // guard can hide it once the session goes stale.
+        this.statusBar.updateContext(
+          ClaudeDataLoader.getCurrentContextInfo(
+            this.cache.records,
+            vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
+          )
+        );
         return;
       }
 
@@ -574,6 +587,7 @@ export class ClaudeCodeUsageExtension {
       if (records.length === 0) {
         const error = 'No usage records found. Make sure Claude Code is running.';
         this.statusBar.updateUsageData(null, null, error);
+        this.statusBar.updateContext(null);
         if (updateWebview) {
           this.webviewProvider.updateData(null, null, null, null, [], [], [], error, dataDirectory);
         }
@@ -601,6 +615,7 @@ export class ClaudeCodeUsageExtension {
       // Update UI. Quota is pushed asynchronously by the fire-and-forget fetch
       // above; passing undefined leaves the quota item untouched here.
       this.statusBar.updateUsageData(todayData, workspaceTodayData, undefined, undefined);
+      this.statusBar.updateContext(ClaudeDataLoader.getCurrentContextInfo(records, workspacePath));
       if (updateWebview) {
         this.webviewProvider.updateData(sessionData, todayData, monthData, allTimeData, dailyDataForMonth, dailyDataForAllTime, hourlyDataForToday, undefined, dataDirectory, records, sessionBreakdown, projectBreakdown, contentAnalysis, branchBreakdown);
       }
@@ -610,6 +625,7 @@ export class ClaudeCodeUsageExtension {
       console.error('Error refreshing Claude Code usage data:', error);
 
       this.statusBar.updateUsageData(null, null, errorMessage);
+      this.statusBar.updateContext(null);
       if (manualTrigger || !this.getConfiguration().pauseDashboardRefresh) {
         this.webviewProvider.updateData(null, null, null, null, [], [], [], errorMessage, null);
       }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -52,6 +52,8 @@ export interface Translations {
     quota5h: string;
     quotaWeekly: string;
     quotaHint: string;
+    contextWindow: string;
+    contextHint: string;
     contentAnalysis: string;
     estimatedNote: string;
     byTool: string;
@@ -146,6 +148,8 @@ const translations: Record<SupportedLanguage, Translations> = {
       quota5h: '5-hour',
       quotaWeekly: 'Weekly',
       quotaHint: 'Real data from Anthropic /usage.',
+      contextWindow: 'Context window',
+      contextHint: 'Estimated from the session log — updates with the next message; /clear or compaction may not show immediately.',
       contentAnalysis: 'Content',
       estimatedNote: 'Estimated from text length — relative shares are reliable, absolute figures are approximate.',
       byTool: 'Tool Results by Tool',
@@ -249,6 +253,8 @@ const translations: Record<SupportedLanguage, Translations> = {
       quota5h: "5 Stunden",
       quotaWeekly: "Woche",
       quotaHint: "Echte Daten von Anthropic /usage.",
+      contextWindow: "Kontextfenster",
+      contextHint: "Aus dem Sitzungsprotokoll geschätzt — aktualisiert sich mit der nächsten Nachricht; /clear oder Komprimierung erscheint ggf. verzögert.",
       contentAnalysis: "Inhalt",
       estimatedNote: "Aus Textlänge geschätzt — relative Anteile sind verlässlich, absolute Werte ungefähr.",
       byTool: "Tool-Ergebnisse nach Tool",
@@ -355,6 +361,8 @@ const translations: Record<SupportedLanguage, Translations> = {
       quota5h: '5 小時',
       quotaWeekly: '每週',
       quotaHint: '來自 Anthropic /usage 的真實資料。',
+      contextWindow: '上下文視窗',
+      contextHint: '依工作階段日誌估算，於下一則訊息更新；/clear 或壓縮後可能不會立即反映。',
       contentAnalysis: '內容分析',
       estimatedNote: '由文字長度估算 —— 相對佔比可靠,絕對數值為近似值。',
       byTool: '各工具結果用量',
@@ -458,6 +466,8 @@ const translations: Record<SupportedLanguage, Translations> = {
       quota5h: '5 小时',
       quotaWeekly: '每周',
       quotaHint: '来自 Anthropic /usage 的真实数据。',
+      contextWindow: '上下文窗口',
+      contextHint: '根据会话日志估算，将在下一条消息时更新；/clear 或压缩后可能不会立即反映。',
       contentAnalysis: '内容分析',
       estimatedNote: '由文本长度估算 —— 相对占比可靠,绝对数值为近似值。',
       byTool: '各工具结果用量',
@@ -561,6 +571,8 @@ const translations: Record<SupportedLanguage, Translations> = {
       quota5h: '5時間',
       quotaWeekly: '週間',
       quotaHint: 'Anthropic /usage からの実データ。',
+      contextWindow: 'コンテキストウィンドウ',
+      contextHint: 'セッションログからの推定値で、次のメッセージで更新されます。/clear や圧縮は即時反映されない場合があります。',
       contentAnalysis: 'コンテンツ',
       estimatedNote: 'テキスト長からの推定値 — 相対割合は信頼でき、絶対値は概算です。',
       byTool: 'ツール別の結果使用量',
@@ -665,6 +677,8 @@ const translations: Record<SupportedLanguage, Translations> = {
       quota5h: '5시간',
       quotaWeekly: '주간',
       quotaHint: 'Anthropic /usage의 실제 데이터입니다.',
+      contextWindow: '컨텍스트 윈도우',
+      contextHint: '세션 로그 기반 추정치이며 다음 메시지에서 갱신됩니다. /clear나 압축은 즉시 반영되지 않을 수 있습니다.',
       contentAnalysis: '콘텐츠',
       estimatedNote: '텍스트 길이로 추정 — 상대 비율은 신뢰할 수 있고 절대값은 근사치입니다.',
       byTool: '도구별 결과 사용량',

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -54,6 +54,7 @@ export interface Translations {
     quotaHint: string;
     contextWindow: string;
     contextHint: string;
+    contextCostHint: string;
     contentAnalysis: string;
     estimatedNote: string;
     byTool: string;
@@ -150,6 +151,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       quotaHint: 'Real data from Anthropic /usage.',
       contextWindow: 'Context window',
       contextHint: 'Estimated from the session log — updates with the next message; /clear or compaction may not show immediately.',
+      contextCostHint: 'Longer sessions cost more even when cached.\n/compact mid-task, /clear when switching tasks.',
       contentAnalysis: 'Content',
       estimatedNote: 'Estimated from text length — relative shares are reliable, absolute figures are approximate.',
       byTool: 'Tool Results by Tool',
@@ -255,6 +257,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       quotaHint: "Echte Daten von Anthropic /usage.",
       contextWindow: "Kontextfenster",
       contextHint: "Aus dem Sitzungsprotokoll geschätzt — aktualisiert sich mit der nächsten Nachricht; /clear oder Komprimierung erscheint ggf. verzögert.",
+      contextCostHint: "Längere Sitzungen kosten mehr, auch im Cache.\n/compact während der Aufgabe, /clear beim Themenwechsel.",
       contentAnalysis: "Inhalt",
       estimatedNote: "Aus Textlänge geschätzt — relative Anteile sind verlässlich, absolute Werte ungefähr.",
       byTool: "Tool-Ergebnisse nach Tool",
@@ -363,6 +366,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       quotaHint: '來自 Anthropic /usage 的真實資料。',
       contextWindow: '上下文視窗',
       contextHint: '依工作階段日誌估算，於下一則訊息更新；/clear 或壓縮後可能不會立即反映。',
+      contextCostHint: '工作階段長，成本高。\n任務中用 /compact，切換任務時用 /clear。',
       contentAnalysis: '內容分析',
       estimatedNote: '由文字長度估算 —— 相對佔比可靠,絕對數值為近似值。',
       byTool: '各工具結果用量',
@@ -468,6 +472,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       quotaHint: '来自 Anthropic /usage 的真实数据。',
       contextWindow: '上下文窗口',
       contextHint: '根据会话日志估算，将在下一条消息时更新；/clear 或压缩后可能不会立即反映。',
+      contextCostHint: '会话长，成本高。\n任务中用 /compact，切换任务时用 /clear。',
       contentAnalysis: '内容分析',
       estimatedNote: '由文本长度估算 —— 相对占比可靠,绝对数值为近似值。',
       byTool: '各工具结果用量',
@@ -573,6 +578,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       quotaHint: 'Anthropic /usage からの実データ。',
       contextWindow: 'コンテキストウィンドウ',
       contextHint: 'セッションログからの推定値で、次のメッセージで更新されます。/clear や圧縮は即時反映されない場合があります。',
+      contextCostHint: 'セッションが長いほど、キャッシュがあってもコストは増えます。\n作業中は /compact、タスク切り替え時は /clear を。',
       contentAnalysis: 'コンテンツ',
       estimatedNote: 'テキスト長からの推定値 — 相対割合は信頼でき、絶対値は概算です。',
       byTool: 'ツール別の結果使用量',
@@ -679,6 +685,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       quotaHint: 'Anthropic /usage의 실제 데이터입니다.',
       contextWindow: '컨텍스트 윈도우',
       contextHint: '세션 로그 기반 추정치이며 다음 메시지에서 갱신됩니다. /clear나 압축은 즉시 반영되지 않을 수 있습니다.',
+      contextCostHint: '세션이 길수록 캐시가 있어도 비용이 늘어납니다.\n작업 중에는 /compact, 작업 전환 시 /clear.',
       contentAnalysis: '콘텐츠',
       estimatedNote: '텍스트 길이로 추정 — 상대 비율은 신뢰할 수 있고 절대값은 근사치입니다.',
       byTool: '도구별 결과 사용량',

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -1,11 +1,15 @@
 import * as vscode from 'vscode';
-import { ClaudeApiUsageResponse, ClaudeUsageLimit, UsageData } from './types';
+import { ClaudeApiUsageResponse, ClaudeUsageLimit, ContextWindowInfo, UsageData } from './types';
 import { I18n } from './i18n';
 
 export class StatusBarManager {
   private statusBarItem: vscode.StatusBarItem;
   private quotaItem: vscode.StatusBarItem;
+  private contextItem: vscode.StatusBarItem;
   private isLoading: boolean = false;
+  // Per-item visibility, driven by the showCost / showContext settings.
+  private showCost: boolean = true;
+  private showContext: boolean = true;
 
   constructor() {
     this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
@@ -15,6 +19,10 @@ export class StatusBarManager {
     // A second, quieter item for the real usage-limit indicator.
     this.quotaItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 99);
     this.quotaItem.command = 'claudeCodeUsage.showDetails';
+
+    // Context-window fill of the current session (like /context).
+    this.contextItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 98);
+    this.contextItem.command = 'claudeCodeUsage.showDetails';
 
     // Visible from t=0: an empty-text status bar item renders as nothing, so
     // without this the extension appears "missing" until the first full
@@ -26,6 +34,31 @@ export class StatusBarManager {
   setLoading(loading: boolean): void {
     this.isLoading = loading;
     this.updateStatusBar();
+  }
+
+  /** Apply the showCost / showContext settings. Hiding takes effect
+   * immediately; re-showing happens on the next data update (the caller
+   * triggers a refresh right after a config change). */
+  setVisibility(showCost: boolean, showContext: boolean): void {
+    this.showCost = showCost;
+    this.showContext = showContext;
+    if (!showCost) {
+      this.statusBarItem.hide();
+    }
+    if (!showContext) {
+      this.contextItem.hide();
+    }
+  }
+
+  /** Show or hide the cost item per the showCost setting. Every method that
+   * sets its text calls this, so the item reappears as soon as the setting
+   * is turned back on. */
+  private applyCostVisibility(): void {
+    if (this.showCost) {
+      this.statusBarItem.show();
+    } else {
+      this.statusBarItem.hide();
+    }
   }
 
   updateUsageData(
@@ -61,6 +94,7 @@ export class StatusBarManager {
     if (this.isLoading) {
       this.statusBarItem.text = `$(sync~spin) ${I18n.t.statusBar.loading}`;
       this.statusBarItem.tooltip = I18n.t.statusBar.loading;
+      this.applyCostVisibility();
       return;
     }
   }
@@ -83,6 +117,42 @@ export class StatusBarManager {
 
     this.statusBarItem.tooltip = this.createTooltip(todayData, ws);
     this.statusBarItem.backgroundColor = undefined;
+    this.applyCostVisibility();
+  }
+
+  /**
+   * Update the context-window indicator with the current session's fill
+   * (estimated from the latest log record — see getCurrentContextInfo).
+   * Hidden when there is no current session or the setting is off.
+   */
+  updateContext(info: ContextWindowInfo | null): void {
+    if (!info || !this.showContext || info.windowTokens <= 0) {
+      this.contextItem.hide();
+      return;
+    }
+    const pct = Math.min(100, (info.contextTokens / info.windowTokens) * 100);
+    this.contextItem.text = `$(layers) ${Math.round(pct)}%`;
+
+    // Same thresholds as the quota item: amber at 80%, red at 95%.
+    if (pct >= 95) {
+      this.contextItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
+    } else if (pct >= 80) {
+      this.contextItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
+    } else {
+      this.contextItem.backgroundColor = undefined;
+    }
+
+    const t = I18n.t.popup;
+    const md = new vscode.MarkdownString();
+    md.supportThemeIcons = true;
+    md.appendMarkdown(`**${t.contextWindow}** — ${info.model}\n\n`);
+    md.appendMarkdown(
+      `$(layers) ${I18n.formatNumber(info.contextTokens)} / ${I18n.formatNumber(info.windowTokens)} ` +
+        `(${pct.toFixed(1)}%)\n\n`
+    );
+    md.appendMarkdown(`*${t.contextHint}*`);
+    this.contextItem.tooltip = md;
+    this.contextItem.show();
   }
 
   /**
@@ -195,12 +265,14 @@ export class StatusBarManager {
     this.statusBarItem.text = `$(circle-slash) ${I18n.t.statusBar.noData}`;
     this.statusBarItem.tooltip = I18n.t.statusBar.notRunning;
     this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
+    this.applyCostVisibility();
   }
 
   private showError(error: string): void {
     this.statusBarItem.text = `$(error) ${I18n.t.statusBar.error}`;
     this.statusBarItem.tooltip = error;
     this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
+    this.applyCostVisibility();
   }
 
   /**
@@ -360,5 +432,6 @@ export class StatusBarManager {
   dispose(): void {
     this.statusBarItem.dispose();
     this.quotaItem.dispose();
+    this.contextItem.dispose();
   }
 }

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -150,7 +150,8 @@ export class StatusBarManager {
       `$(layers) ${I18n.formatNumber(info.contextTokens)} / ${I18n.formatNumber(info.windowTokens)} ` +
         `(${pct.toFixed(1)}%)\n\n`
     );
-    md.appendMarkdown(`*${t.contextHint}*`);
+    md.appendMarkdown(t.contextCostHint.split('\n').map((l) => `*${l}*`).join('  \n'));
+    md.appendMarkdown(`\n\n*${t.contextHint}*`);
     this.contextItem.tooltip = md;
     this.contextItem.show();
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,6 +131,10 @@ export interface ExtensionConfig {
   // to use the system timezone. Useful for users in devcontainers or
   // sandboxes whose system zone doesn't match their actual zone.
   timezone: string;
+  // Show today's cost item in the status bar.
+  showCost: boolean;
+  // Show the current session's context-window fill in the status bar.
+  showContext: boolean;
   // Fetch real 5-hour / weekly limit utilisation via Claude Code's OAuth session.
   usageLimitTracking: boolean;
   // LLM "usage advice" feature (OpenAI-compatible endpoint, e.g. DeepSeek).
@@ -174,6 +178,14 @@ export interface BranchUsage {
   sessionCount: number;
   lastSeen: Date;
   data: UsageData;
+}
+
+// Context-window fill of the current conversation, estimated from the
+// session's most recent log record (mirrors what /context shows).
+export interface ContextWindowInfo {
+  contextTokens: number;
+  windowTokens: number;
+  model: string;
 }
 
 // OAuth credentials written by Claude Code at ~/.claude/.credentials.json.


### PR DESCRIPTION
Two new settings:

- claudeCodeUsage.showCost (default true) — hide the status-bar cost item for users who only want the quota / context indicators; the dashboard still shows all cost figures.
- claudeCodeUsage.showContext (default true) — a new status-bar item showing the current session's context-window fill as a percentage, like Claude Code's /context. Estimated from the session's latest log record (input + cache read + cache write tokens) against the model's window size (200K, or 1M for "[1m]" long-context variants). Amber at 80%, red at 95% (same thresholds as the quota item); hidden after 5h of inactivity (same recency rule as the current-session figure), with the recency check re-run on idle ticks so a stale percentage never lingers.

Also syncs package-lock.json's version field with package.json (2.0.2).

<!--
Thanks for contributing! A consistently-structured PR makes review fast —
and lets our (future) automated triage assist with first-pass analysis.
Keep the section headings; fill what applies, delete what doesn't.
-->

## Summary

<!-- What does this PR do, in 2–4 sentences? What problem does it solve? -->

## Linked issues

<!-- e.g. "Closes #42" / "Relates to #17". Write "None" if standalone. -->

## Type of change

<!-- Keep one: -->
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (existing behaviour differs afterwards)
- [ ] Documentation / CI / chore

## How was this tested?

<!-- Manual steps in the Extension Development Host (F5), test runs, or
     screenshots for UI changes. "Compiles" alone is not testing. -->

## Checklist

- [ ] `npm run compile` is clean
- [ ] User-facing strings go through `I18n` with **all six languages** filled
- [ ] `CHANGELOG.md` updated (user-visible changes)
- [ ] `README.md` updated if behaviour/settings changed
- [ ] New settings default to existing behaviour (opt-in)
- [ ] No new runtime dependencies
