### PR TITLE
test: add node:test framework with a seed pricing test (#25)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+# Run the test suite on every push and pull request.
+#
+# What this does:
+#   1. Checks out the commit.
+#   2. Installs dependencies (npm ci).
+#   3. Runs `npm test`, which compiles TypeScript and executes the
+#      node:test suite against the compiled output in out/test/.
+#
+# A red check here means a regression in the pure-logic modules (pricing /
+# aggregation / quota / i18n) — visible on the PR before merge. To make it
+# actually block merging, add "Test" as a required status check under the
+# repo's branch-protection rules (Settings → Branches).
+
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,6 +3,7 @@
 .claude/**
 .github/**
 src/**
+out/test/**
 CLAUDE.md
 CLAUDE.local.md
 CONTRIBUTING.md

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "test": "npm run compile && node --test \"out/test/**/*.test.js\""
+    "test": "npm run compile && node --test out/test/*.test.js"
   },
   "devDependencies": {
     "@types/glob": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,8 @@
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
-    "watch": "tsc -watch -p ./"
+    "watch": "tsc -watch -p ./",
+    "test": "npm run compile && node --test \"out/test/**/*.test.js\""
   },
   "devDependencies": {
     "@types/glob": "^9.0.0",

--- a/src/test/pricing.test.ts
+++ b/src/test/pricing.test.ts
@@ -2,9 +2,9 @@
 //
 // Approach: Node's built-in test runner (`node:test` + `node:assert`) against
 // the *compiled* output — zero new runtime/dev dependencies. Tests live in
-// `src/test/` so `tsc` (rootDir: src) emits them to `out/test/`, then
-// `node --test out/test/` runs every `*.test.js` there. See the `test` script
-// in package.json.
+// `src/test/` so `tsc` (rootDir: src) emits them to `out/test/`, then the
+// `test` script runs `node --test out/test/*.test.js` — a shell-expanded glob,
+// so it works on Node 20 too (node's own glob support only landed in 21).
 //
 // Only pure, dependency-free modules belong here — anything importing the
 // `vscode` API needs the heavier @vscode/test-electron harness instead. This

--- a/src/test/pricing.test.ts
+++ b/src/test/pricing.test.ts
@@ -1,0 +1,41 @@
+// Seed test for the project's test suite (see issue #25).
+//
+// Approach: Node's built-in test runner (`node:test` + `node:assert`) against
+// the *compiled* output — zero new runtime/dev dependencies. Tests live in
+// `src/test/` so `tsc` (rootDir: src) emits them to `out/test/`, then
+// `node --test out/test/` runs every `*.test.js` there. See the `test` script
+// in package.json.
+//
+// Only pure, dependency-free modules belong here — anything importing the
+// `vscode` API needs the heavier @vscode/test-electron harness instead. This
+// one file is intentionally a single illustrative example; follow the same
+// pattern to cover aggregation, quota-window handling, and i18n next.
+
+import { test } from 'node:test';
+import * as assert from 'node:assert/strict';
+
+import { calculateCostFromTokens, getModelPricing } from '../pricing';
+
+test('calculateCostFromTokens prices a known model from its per-token rates', () => {
+  // Opus current tier: $5 / $25 / $6.25 / $0.50 per million in/out/write/read.
+  const cost = calculateCostFromTokens(
+    {
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+      cache_creation_input_tokens: 1_000_000,
+      cache_read_input_tokens: 1_000_000,
+    },
+    'claude-opus-4-8'
+  );
+
+  // 5 + 25 + 6.25 + 0.5 = 36.75. Use a tolerance — per-token rates are floats.
+  assert.ok(Math.abs(cost - 36.75) < 1e-9, `expected ~36.75, got ${cost}`);
+});
+
+test('getModelPricing falls back to the right family for an unknown snapshot', () => {
+  // An unreleased Opus snapshot isn't in the exact table; it should still
+  // resolve to the current Opus tier ($5/MTok input) rather than a wrong rate.
+  const pricing = getModelPricing('claude-opus-4-9-20990101');
+  assert.ok(pricing, 'expected a fallback pricing object, got null');
+  assert.equal(pricing!.input_cost_per_token, 5 / 1_000_000);
+});


### PR DESCRIPTION
Closes #25.

Sets up a lightweight test foundation using **Node's built-in test runner** (`node:test` + `node:assert`) against compiled output — the approach you preferred in the issue, with **zero new dependencies**. Branched off fresh `main` (v2.0.2) as you suggested.

## What's here

Kept intentionally to **a single seed test** so the pattern is clear without a big drop:

- **`src/test/pricing.test.ts`** — covers `pricing.ts` because it's pure logic with no `vscode` import. Two assertions: known-model cost calculation (Opus current tier → $36.75 for 1M of each token type) and the family-aware fallback for an unrecognised snapshot.
- **`package.json`** — `test` script: `npm run compile && node --test "out/test/**/*.test.js"`. Tests live in `src/test/`, so `tsc` (`rootDir: src`) emits them to `out/test/`.
- **`.vscodeignore`** — adds `out/test/**` so the compiled tests never ship in the `.vsix` (verified with `vsce ls`).
- **`.github/workflows/test.yml`** — runs `npm test` on pushes to `main` and on every PR.

## Notes for review

- Only pure, dependency-free modules belong in this harness. Anything touching the live `vscode` API would need the heavier `@vscode/test-electron` setup — out of scope here.
- The repo's `tsconfig.json` has no `esModuleInterop`, so the test uses namespace imports (`import { test }` / `import * as assert`) rather than default imports.
- The CI workflow reports a check but won't *block* merge until `Test` is added as a required status check in the repo's branch-protection settings — that's an owner-side step.

Local run: `npm test` → 2 pass, 0 fail. Natural next targets following the same pattern: aggregation, quota-window handling, and i18n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)