### PR TITLE
docs: document test expectations (CONTRIBUTING + CLAUDE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,9 +66,10 @@ npx @vscode/vsce package   # build a .vsix
 
 - **Commit hygiene:** one meaningful commit per logical change; avoid a stream
   of "fix the previous fix" commits. RC branches squash-merge to `main`.
-- **Tests:** pure-logic modules (pricing, aggregation, quota-window handling,
-  i18n) are the high-value test targets. A `node:test` suite is planned
-  (see issue #25).
+- **Tests:** a `node:test` suite runs against compiled output (`npm test`; see
+  `src/test/` and CONTRIBUTING). Pure-logic modules (pricing, aggregation,
+  quota-window handling, i18n) are the high-value targets; `pricing.ts` has the
+  first coverage, the rest are still open.
 - **Data is read-only:** the extension never writes to `~/.claude/`.
 
 ## Documentation Maintenance

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,12 @@ npm test          # compiles, then runs node --test over out/test/*.test.js
 
 CI runs the same command on every PR (`.github/workflows/test.yml`).
 
-**Where tests live.** Put test files in `src/test/` named `*.test.ts`. Because
-`tsc` is configured with `rootDir: src`, they compile to `out/test/` where the
-runner picks them up. They're excluded from the packaged `.vsix`.
+**Where tests live.** Put test files **directly** in `src/test/`, named
+`*.test.ts`. Because `tsc` is configured with `rootDir: src`, they compile to
+`out/test/` where the runner picks them up, and they're excluded from the
+packaged `.vsix`. Keep the directory flat — the `test` script globs
+`out/test/*.test.js` (a single level, so it stays portable across Node
+versions), which means files in nested subfolders would be silently skipped.
 
 **What to test.** This harness is for **pure, dependency-free logic** — modules
 that don't import the `vscode` API:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,12 +38,38 @@ writes to your Claude data.
 
 ## Tests
 
-There isn't a full test suite yet (tracked in
-[#25](https://github.com/jack21/ClaudeCodeUsage/issues/25)). The pure-logic
-modules — pricing (`pricing.ts`), aggregation (`dataLoader.ts`), quota-window
-handling (`statusBar.ts`), i18n formatting (`i18n.ts`) — are the high-value
-targets for `node:test`. If you add logic to these, lightweight tests are very
-welcome.
+Tests use **Node's built-in runner** (`node:test` + `node:assert`) — no extra
+dependencies. They run against the *compiled* output:
+
+```bash
+npm test          # compiles, then runs node --test over out/test/*.test.js
+```
+
+CI runs the same command on every PR (`.github/workflows/test.yml`).
+
+**Where tests live.** Put test files in `src/test/` named `*.test.ts`. Because
+`tsc` is configured with `rootDir: src`, they compile to `out/test/` where the
+runner picks them up. They're excluded from the packaged `.vsix`.
+
+**What to test.** This harness is for **pure, dependency-free logic** — modules
+that don't import the `vscode` API:
+
+- pricing & cost calculation (`pricing.ts`)
+- aggregation: daily / weekly / monthly / all-time (`dataLoader.ts`)
+- quota-window handling (`statusBar.ts`)
+- i18n formatting (`i18n.ts`)
+
+If you add or change logic in these, please add a test. `src/test/pricing.test.ts`
+is a worked example to copy from. Prefer asserting on **observable behaviour**
+(a computed cost, a resolved pricing tier) over implementation details, and add
+a case for the tricky edge you just fixed so it can't regress.
+
+**What doesn't belong here.** Anything that touches the live `vscode` API
+(status-bar wiring, webview, commands) needs the heavier
+[`@vscode/test-electron`](https://github.com/microsoft/vscode-test) harness,
+which isn't set up yet. If you need it, raise it on
+[#25](https://github.com/jack21/ClaudeCodeUsage/issues/25) first so we keep the
+two harnesses cleanly separated.
 
 ## Releases
 


### PR DESCRIPTION
Documents the test harness now that the project has one, so contributors know what's expected.

**`CONTRIBUTING.md`** — rewrites the Tests section:
- How to run (`npm test`) and that CI runs the same on every PR.
- Where tests live (`src/test/*.test.ts` → compiled to `out/test/`), and that the directory must stay **flat** — the script globs `out/test/*.test.js` a single level deep (kept single-level for Node-version portability), so nested files would be silently skipped.
- What belongs here — pure, dependency-free logic (pricing, aggregation, quota, i18n) — with a pointer to the worked example.
- What doesn't: live `vscode` API code needs `@vscode/test-electron`, not set up yet.

**`CLAUDE.md`** — updates the Tests convention from "a `node:test` suite is planned (see #25)" to reflect that it now exists.

### ⚠️ Depends on #32

This documents the framework added in #32, so **please merge #32 first**. Kept as a separate, discussion-light docs PR on purpose — single concern, can merge right after the framework lands. Happy to rebase if #32 changes anything material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)