### PR TITLE
Surface the weekly Opus limit in the status bar (opt-in showOpusWeekly)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ upstream release: 1.0.8). Format follows [Keep a Changelog](https://keepachangel
 ## [Unreleased]
 
 ### Added
+- **`claudeCodeUsage.showOpusWeekly` setting** — opt-in (default off) that
+  appends the weekly Opus limit (`opus:NN%`) to the status-bar quota item,
+  after the 5-hour and weekly figures. Only shown when the account has a live
+  weekly-Opus window.
 - **Context-window indicator** in the status bar — shows the current
   session's context fill as a percentage (like `/context`), estimated from
   the latest log record (`input + cache read + cache write` tokens vs the

--- a/README-en.md
+++ b/README-en.md
@@ -53,6 +53,7 @@ Open Settings (`Ctrl+,`) and search for **`Claude Code Usage`**. All settings ar
 - `language` — UI language (`auto` / `en` / `zh-TW` / `zh-CN` / `ja` / `ko`).
 - `timezone` — IANA timezone for date display (e.g. `Asia/Hong_Kong`).
 - `usageLimitTracking` — show the real 5h / weekly quota indicator.
+- `showOpusWeekly` — also append the weekly Opus limit (`opus:NN%`) after the 5h / weekly figures (off by default).
 - `showCost` / `showContext` — toggle the cost item and the context-window fill indicator (like `/context`) in the status bar.
 - Each of these status-bar items is opt-out — set `usageLimitTracking`, `showCost`, or `showContext` to `false` to hide just that one.
 - `advice.apiKey` — API key for the AI advice feature (OpenAI-compatible).

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ reasonable.
 | `compactNumbers` | `false` | Show `1.2M` / `345K` instead of full numbers. |
 | `timezone` | `""` | IANA timezone for date display (e.g. `Asia/Hong_Kong`). |
 | `usageLimitTracking` | `true` | Show real 5h / weekly quota in the status bar. |
+| `showOpusWeekly` | `false` | Also show the weekly Opus limit (`opus:NN%`) in the status bar, after the 5h / weekly figures. |
 | `showCost` | `true` | Show today's cost item in the status bar. |
 | `showContext` | `true` | Show the current session's context-window fill (like `/context`). Set this, `showCost`, or `usageLimitTracking` to `false` to hide that status-bar item. |
 | `enableContentAnalysis` | `true` | Run the Content tab token analysis. |

--- a/package.json
+++ b/package.json
@@ -97,6 +97,11 @@
           "default": true,
           "description": "Show real 5-hour and weekly limit utilisation in the status bar. Uses Claude Code's existing sign-in (~/.claude/.credentials.json or macOS Keychain) — no configuration needed."
         },
+        "claudeCodeUsage.showOpusWeekly": {
+          "type": "boolean",
+          "default": false,
+          "description": "Also show the weekly Opus limit (opus:NN%) in the status bar, after the 5-hour and weekly figures. Requires usage-limit tracking to be enabled."
+        },
         "claudeCodeUsage.advice.apiKey": {
           "type": "string",
           "default": "",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -277,7 +277,7 @@ export class ClaudeCodeUsageExtension {
     I18n.setDecimalPlaces(config.decimalPlaces);
     I18n.setCompactNumbers(config.compactNumbers);
     I18n.setTimezone(config.timezone);
-    this.statusBar.setVisibility(config.showCost, config.showContext);
+    this.statusBar.setVisibility(config.showCost, config.showContext, config.showOpusWeekly);
 
     // Listen for configuration changes
     vscode.workspace.onDidChangeConfiguration(e => {
@@ -299,6 +299,7 @@ export class ClaudeCodeUsageExtension {
       showCost: config.get('showCost', true),
       showContext: config.get('showContext', true),
       usageLimitTracking: config.get('usageLimitTracking', true),
+      showOpusWeekly: config.get('showOpusWeekly', false),
       // apiKey is the gate for the advice feature: ONLY read the new dotted
       // key. We deliberately do NOT fall back to the pre-2.0 flat
       // `adviceApiKey` here — otherwise users who clear the new key in
@@ -326,7 +327,7 @@ export class ClaudeCodeUsageExtension {
     I18n.setDecimalPlaces(config.decimalPlaces);
     I18n.setCompactNumbers(config.compactNumbers);
     I18n.setTimezone(config.timezone);
-    this.statusBar.setVisibility(config.showCost, config.showContext);
+    this.statusBar.setVisibility(config.showCost, config.showContext, config.showOpusWeekly);
 
     // Restart auto-refresh with new interval
     this.startAutoRefresh();

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -10,6 +10,8 @@ export class StatusBarManager {
   // Per-item visibility, driven by the showCost / showContext settings.
   private showCost: boolean = true;
   private showContext: boolean = true;
+  // When true, append the weekly Opus limit (opus:NN%) to the quota item.
+  private showOpusWeekly: boolean = false;
 
   constructor() {
     this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
@@ -39,9 +41,10 @@ export class StatusBarManager {
   /** Apply the showCost / showContext settings. Hiding takes effect
    * immediately; re-showing happens on the next data update (the caller
    * triggers a refresh right after a config change). */
-  setVisibility(showCost: boolean, showContext: boolean): void {
+  setVisibility(showCost: boolean, showContext: boolean, showOpusWeekly: boolean = false): void {
     this.showCost = showCost;
     this.showContext = showContext;
+    this.showOpusWeekly = showOpusWeekly;
     if (!showCost) {
       this.statusBarItem.hide();
     }
@@ -172,7 +175,8 @@ export class StatusBarManager {
     const live = this.liveWindows(usageLimits);
     const fiveHour = live?.five_hour;
     const weekly = live?.seven_day;
-    if (!fiveHour && !weekly) {
+    const opus = live?.seven_day_opus;
+    if (!fiveHour && !weekly && !(this.showOpusWeekly && opus)) {
       this.quotaItem.hide();
       return;
     }
@@ -186,6 +190,10 @@ export class StatusBarManager {
     if (weekly) {
       worstPct = Math.max(worstPct, weekly.utilization);
       parts.push(`wk:${Math.round(weekly.utilization)}%`);
+    }
+    if (this.showOpusWeekly && opus) {
+      worstPct = Math.max(worstPct, opus.utilization);
+      parts.push(`opus:${Math.round(opus.utilization)}%`);
     }
 
     this.quotaItem.text = `$(dashboard) ${parts.join(' ')}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,9 @@ export interface ExtensionConfig {
   showContext: boolean;
   // Fetch real 5-hour / weekly limit utilisation via Claude Code's OAuth session.
   usageLimitTracking: boolean;
+  // Append the weekly Opus limit (opus:NN%) to the status-bar quota item.
+  // Independent of the 5h/weekly figures; requires usageLimitTracking.
+  showOpusWeekly: boolean;
   // LLM "usage advice" feature (OpenAI-compatible endpoint, e.g. DeepSeek).
   adviceApiKey: string;
   adviceApiUrl: string;


### PR DESCRIPTION
## Summary

The OAuth usage response already includes the weekly Opus window (`seven_day_opus`) and the quota hover tooltip shows it, but the status-bar quota item only ever renders the 5-hour and weekly figures. Anyone running Opus-heavy workloads has no at-a-glance read on their weekly Opus cap. This adds an opt-in `claudeCodeUsage.showOpusWeekly` setting that appends `opus:NN%` after the weekly figure, mirroring the existing `showCost` / `showContext` display toggles.

## Linked issues

None.

## Type of change

- [x] New feature (non-breaking) -> `feature` (minor)

## How was this tested?

`npm run compile` is clean. Loaded in the Extension Development Host: with `showOpusWeekly` on, the quota item renders `5h:.. wk:.. opus:..`; with it off the bar is unchanged from current behaviour. My account had no live weekly-Opus window during testing, so I verified the `opus:NN%` segment specifically by feeding a synthetic `seven_day_opus` window through the usage path -- it renders after `wk:` as intended and is absent when no Opus window exists.

## Checklist

- [x] `npm run compile` is clean
- [ ] The new `opus:` label is hardcoded to match the existing `5h:` / `wk:` sibling labels in `statusBar.ts` (those aren't routed through `I18n` either) -- happy to migrate all three if you'd prefer
- [x] `CHANGELOG.md` updated
- [x] `README.md` / `README-en.md` updated (localized READMEs left for translators rather than pasting untranslated English -- glad to add if you point me at conventions)
- [x] New setting defaults to existing behaviour (opt-in, `false`)
- [x] No new runtime dependencies
